### PR TITLE
[bug]SqlParseUtils.java

### DIFF
--- a/server/src/main/java/edp/davinci/core/utils/SqlParseUtils.java
+++ b/server/src/main/java/edp/davinci/core/utils/SqlParseUtils.java
@@ -228,7 +228,7 @@ public class SqlParseUtils {
         jobRequest.setParams(configMap);
 
         jobRequest.setLabels(Arrays.asList(codeLabel));
-        return CustomVariableUtils.replaceCustomVar(jobRequest, "sql")._2;
+        return CustomVariableUtils.replaceCustomVar(jobRequest, "sql");
     }
 
 


### PR DESCRIPTION
在linkis1.1.2以上版本中，CustomVariableUtils.replaceCustomVar(jobRequest, "sql")._2改为CustomVariableUtils.replaceCustomVar(jobRequest, "sql")